### PR TITLE
Use yaml.dump() to write front-matter

### DIFF
--- a/jekyllToHugo.py
+++ b/jekyllToHugo.py
@@ -82,10 +82,6 @@ def handlePost(filename, path):
                 if not y[key] == None:
                     if key == 'date':
                         nf.write(key + ": \"" + time.strftime("%Y-%m-%d")  + "\"" + os.linesep)
-                    elif not  isinstance(y[key], types.StringTypes):
-                        nf.write(key + ":" + os.linesep)
-                        for d in y[key]:
-                            nf.write("- " + d + os.linesep)
                     elif key in ["tags","categories"]:
                         nf.write(key + ":" + str(y[key].split(" ")) + os.linesep)
                     elif key == "status":
@@ -94,7 +90,7 @@ def handlePost(filename, path):
                     elif  key == "summary":
                         nf.write("description" + ": \"" + str(y[key])  + "\"" + os.linesep)
                     else:
-                        nf.write(key + ": \"" + str(y[key])  + "\"" + os.linesep)
+                        nf.write(yaml.dump({key: y[key]}, default_flow_style=False))
             if not "date" in y:
                 nf.write("date" + ": \"" + time.strftime("%Y-%m-%d")  + "\"" + os.linesep)
 


### PR DESCRIPTION
Hi,

Thanks you for this great work, this saves me a lot of time!

I had some errors with my (complex) front-matter. 
For instance, with boolean or integer variables, like this :

``` yaml

---
showFooter: true
id: 1337

---
```

It tries to iterate on `showFooter` (because `true` isn't an instance of `types.StringTypes`) and throw an error:

> $ /usr/local/bin/jekyllToHugo.py ../blog/_posts/
> Traceback (most recent call last):
>   File "/usr/local/bin/jekyllToHugo.py", line 124, in <module>
>     handlePost(filename, arguments.source)
>   File "/usr/local/bin/jekyllToHugo.py", line 87, in handlePost
>     for d in y[key]:
> TypeError: 'bool' object is not iterable

We can check all non-iterable type. But I think using `yaml.dump()` is safer to write yaml, and allows us to manage advanced cases. For instance, my code works with a front matter like this:

``` yaml

---
layout: post
status: publish
date: '2016-05-05 22:39:42 +0000'
title: "A sample post"
summary: "Hi!"
id: 1337
showFooter: true
author:
  firstname: Julien
  email: foo@bar.com
tags:
  - foo
  - bar
comments:
  - id: 13
    author: Foo
    date: "2015-12-07"
    comment: "Hi!"
  - id: 37
    author: Bar
    date: "2015-12-08"
    comment: "Hello :)"

---
```

Have a good day,
Julien
